### PR TITLE
Update jquery.align-column.js

### DIFF
--- a/jquery.align-column.js
+++ b/jquery.align-column.js
@@ -22,6 +22,7 @@ $.fn.alignColumn = function (columns, options) {
       console.log('Splitting by ', config.center);
     }
     splitter = function (text) {
+      if(text === undefined) return '';
       var s = text.split(config.center);
       return (s.length == 2) ? [s[0], config.center + s[1]] : [text];
     }


### PR DESCRIPTION
Changed splitter func to always return an empty string if the input text is undefined. If text is undefined, the script messes up, because it tries to call split on undefined.
